### PR TITLE
`toColumnValue()` should treat undefined.

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -289,7 +289,7 @@ function dateToIBMDB(val) {
  */
 IBMDB.prototype.toColumnValue = function(prop, val) {
   debug('IBMDB.prototype.toColumnValue prop=%j val=%j', prop, val);
-  if (val === null) {
+  if (val == null) {
     if (prop.autoIncrement || prop.id) {
       return new ParameterizedSQL('DEFAULT');
     }


### PR DESCRIPTION
`toColumnValue()` should treat undefined.

This fixes all of the test cases for `loopback-connector-db2` for `replaceById`(atomic) and `replaceOrCreate` (non-atomic).

to:/ @qpresley PTAL. Thanks!
