### PR TITLE
Avoid update all in save and updateOrCreate

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -420,7 +420,9 @@ IBMDB.prototype.updateOrCreate = IBMDB.prototype.save =
           }
 
           if (countData[0]['CNT'] > 0) {
-            stmt = self.buildUpdate(model, data.id, data);
+            var where = {};
+            where[id] = data[id];
+            stmt = self.buildUpdate(model, where, data);
           } else {
             stmt = self.buildInsert(model, data);
           }
@@ -429,21 +431,8 @@ IBMDB.prototype.updateOrCreate = IBMDB.prototype.save =
             if (err) {
               return cb(err);
             }
-
-            if (countData[0]['CNT'] > 0) {
-              meta.isNewInstance = false;
-              meta.isNewInstance = false;
-              cb(null, data, meta);
-            } else {
-              stmt = 'SELECT MAX(' + id + ') as id FROM ' + tableName;
-              connection.query(stmt, null, function(err, info) {
-                if (err) {
-                  return cb(err);
-                }
-                data.id = info[0]['CNT'];
-                cb(null, data, meta);
-              });
-            }
+            meta.isNewInstance = countData[0]['CNT'] === 0;
+            cb(null, data, meta);
           });
         });
     };


### PR DESCRIPTION
Avoid update all instances when using save/updateOrCreate

Connect to https://github.com/strongloop/loopback-connector-db2/issues/38

Please review: @loay @superkhau @jannyHou 

CC: @bajtos @qpresley 