### PR TITLE
1.0.5

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -202,6 +202,11 @@ IBMDB.prototype.executeSQL = function(sql, params, options, callback) {
   var conn = self.connection;
   var stmt = {};
 
+  if(!self.connection.connected) {
+    self.dataSource.connected = false;
+    self.dataSource.connecting = false;
+  }
+  
   stmt.noResults = (options && options.noResults) ? options.noResults : false;
 
   if (options.transaction) {

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -202,11 +202,10 @@ IBMDB.prototype.executeSQL = function(sql, params, options, callback) {
   var conn = self.connection;
   var stmt = {};
 
-  if(!self.connection.connected) {
+  if (!self.connection.connected) {
     self.dataSource.connected = false;
     self.dataSource.connecting = false;
   }
-  
   stmt.noResults = (options && options.noResults) ? options.noResults : false;
 
   if (options.transaction) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-ibmdb",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "LoopBack Connector common code for IBM databases",
   "keywords": [
     "IBM",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-ibmdb",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "description": "LoopBack Connector common code for IBM databases",
   "keywords": [
     "IBM",

--- a/test/ibmdb.test.js
+++ b/test/ibmdb.test.js
@@ -1,0 +1,48 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-ibmdb
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+/* eslint-env node, mocha */
+process.env.NODE_ENV = 'test';
+
+require('./init');
+var IBMDB = require('../').IBMDB;
+var assert = require('assert');
+
+before(function (done) {
+    var connectionObj = global.config;
+    var err, data;
+    ibmdb = new IBMDB('db2', connectionObj);
+    ibmdb.connection = {};
+    ibmdb.connection.query = function(stat, callback) {
+        return callback(err, data);
+    };
+
+    ibmdb.connection.connected = false;
+    ibmdb.connection.connecting = false;
+
+    ibmdb.dataSource = ibmdb.datasource = {};
+    ibmdb.dataSource.connected = true;
+    ibmdb.dataSource.connecting = true;
+    done();
+});
+
+describe('IBMDB -> ', function () {
+  describe('executeSQL -> ', function () {
+    it('should set the datasource cnnected/connecting values to false', function (done) {
+
+        var sql = '';
+        var params = '';
+        var options = '';
+
+        ibmdb.connect(function (err, conn) {
+            ibmdb.executeSQL(sql, params, options, function (err, data) {
+                assert.equal(ibmdb.dataSource.connected, false);
+                assert.equal(ibmdb.dataSource.connecting, false);
+                done();
+            });
+        });
+    });
+  });
+});


### PR DESCRIPTION
At a query execution stage, if cli driver returns a connection drop, notifying the datasource that the connection has dropped so that datasource can retry connecting