### PR TITLE
Need to close connections to return to pool

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -199,7 +199,7 @@ IBMDB.prototype.executeSQL = function(sql, params, options, callback) {
 
   var self = this;
 
-  function executeStatement(conn) {
+  function executeStatement(conn, cb) {
     var limit = 0;
     var offset = 0;
     var stmt = {};
@@ -243,23 +243,27 @@ IBMDB.prototype.executeSQL = function(sql, params, options, callback) {
       if (!err) {
         if (more) {
           process.nextTick(function() {
-            return callback(err, data);
+            return cb(err, data);
           });
         }
       }
 
-      callback && callback(err, data);
+      cb && cb(err, data);
     });
   };
 
   if (options.transaction) {
     var conn = options.transaction.connection;
-    executeStatement(conn);
+    executeStatement(conn, function(err, data) {callback(err, data);});
   } else {
     this.connect(function(err, conn) {
       if (err) return callback(err);
 
-      executeStatement(conn);
+      executeStatement(conn, function(err, data){
+        conn.close(function() {;
+          callback(err, data);
+        });
+      });
     });
   }
 };

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -254,13 +254,13 @@ IBMDB.prototype.executeSQL = function(sql, params, options, callback) {
 
   if (options.transaction) {
     var conn = options.transaction.connection;
-    executeStatement(conn, function(err, data) {callback(err, data);});
+    executeStatement(conn, function(err, data) { callback(err, data); });
   } else {
     this.connect(function(err, conn) {
       if (err) return callback(err);
 
-      executeStatement(conn, function(err, data){
-        conn.close(function() {;
+      executeStatement(conn, function(err, data) {
+        conn.close(function() {
           callback(err, data);
         });
       });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "debug": "^2.2.0",
-    "ibm_db": "^0.0.19",
+    "ibm_db": "^1.0.0",
     "loopback-connector": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There was some work left out in a previous PR where we now use pooled connections properly in DB2 and other IBM connectors.  The piece that was left out was closing the connection once finished with it if we are not in a transaction.  This PR will add that which closes a hole where we are currently leaking connections.

@Amir-61 @superkhau  PTAL