### PR TITLE
Add connectorCapabilities global object

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -20,3 +20,8 @@ global.getDataSource = global.getSchema = function(options) {
   var db = new DataSource(require('../'), config);
   return db;
 };
+
+global.connectorCapabilities = {
+  ilike: false,
+  nilike: false,
+};


### PR DESCRIPTION
## Purpose

This PR is to support the new `connectorCapabilities` object added to loopback-datasource-juggler as discussed here: https://github.com/strongloop/loopback-datasource-juggler/pull/1091.

This object will allow connectors to tell the tests in [basic-querying.test.js](https://github.com/strongloop/loopback-datasource-juggler/blob/master/test/basic-querying.test.js) whether or not they support a certain operator, so new operators added do not cause downstream connector tests to fail. Tests run when the operator is supported and do not run when it is not.

## Example

In a connector's `test/init.js`
``` js
global.connectorCapabilities = {
  ilike: false,
  nilike: false,
};
```

In loopback-datasource-juggler `test/basic-querying.test.js`
```js
var itWhenIlikeSupported = connectorCapabilities.ilike ? it : it.skip.bind(it);

itWhenIlikeSupported('should support "like" that is satisfied', function(done) {
  User.find({where: {name: {like: 'John'}}}, function(err, users) {
    if (err) return done(err);
    users.length.should.equal(1);
    users[0].name.should.equal('John Lennon');
    done();
  });
});
```