### PR TITLE
Add initial settings config

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -49,7 +49,7 @@ module.exports = IBMDB;
 function IBMDB(name, settings) {
   debug('IBMDB constructor settings: %j', settings);
   SQLConnector.call(this, name, settings);
-  this.client = new Driver.Pool();
+  // this.client = new Driver.Pool();
   this.dbname = (settings.database || settings.db || 'testdb');
   this.dsn = settings.dsn;
   this.hostname = (settings.hostname || settings.host);
@@ -57,6 +57,16 @@ function IBMDB(name, settings) {
   this.password = settings.password;
   this.portnumber = settings.port;
   this.protocol = (settings.protocol || 'TCPIP');
+
+  // Save off the connectionOptions passed in for connection pooling
+  this.connectionOptions = {};
+  this.connectionOptions.minPoolSize = (settings.minPoolSize || 0);
+  this.connectionOptions.maxPoolSize = (settings.maxPoolSize || 0);
+  this.connectionOptions.connectionTimeout = (settings.connectionTimeout || 60);
+
+  // Create the Connection Pool object.  It will be initialized once we
+  // have the connection string prepped below.
+  this.client = new Driver.Pool(this.connectionOptions);
 
   var dsn = settings.dsn;
   if (dsn) {
@@ -85,6 +95,8 @@ function IBMDB(name, settings) {
 
     this.connStr += ';CurrentSchema=' + this.schema;
   }
+
+  this.client.init(this.connectionOptions.minPoolSize, this.connStr);
 };
 
 util.inherits(IBMDB, SQLConnector);

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -49,7 +49,7 @@ module.exports = IBMDB;
 function IBMDB(name, settings) {
   debug('IBMDB constructor settings: %j', settings);
   SQLConnector.call(this, name, settings);
-  // this.client = new Driver.Pool();
+
   this.dbname = (settings.database || settings.db || 'testdb');
   this.dsn = settings.dsn;
   this.hostname = (settings.hostname || settings.host);


### PR DESCRIPTION
Initial PR for adding connection pooling settings which will soon be supported in a node-ibm_db release.