### PR TITLE
remove connect/lazyconnect

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -26,15 +26,7 @@ var Transaction = IBMDB.Transaction = SQLConnector.Transaction;
 exports.initialize = function(ds, cb) {
   ds.connector = new IBMDB('IBMDB', ds.settings);
   ds.connector.dataSource = ds;
-  if (cb) {
-    if (ds.settings.lazyConnect) {
-      process.nextTick(function() {
-        cb();
-      });
-    } else {
-      ds.connector.connect(cb);
-    }
-  }
+  cb();
 };
 
 module.exports = IBMDB;


### PR DESCRIPTION
Lazy connect does not hold meaning in the IBM Database connectors.  On initialization there is no connection acquired for the connector.  If the user specifies a min or max connection pool size in the settings past in on initialization then the underlying connection pool in the node-ibm_db module will have connections ready.