### PR TITLE
Fixed issue with datasource.connection

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -52,8 +52,8 @@ function IBMDB(name, settings) {
 
   // Save off the connectionOptions passed in for connection pooling
   this.connectionOptions = {};
-  this.connectionOptions.minPoolSize = (settings.minPoolSize || 0);
-  this.connectionOptions.maxPoolSize = (settings.maxPoolSize || 0);
+  this.connectionOptions.minPoolSize = (settings.minPoolSize || 1);
+  this.connectionOptions.maxPoolSize = (settings.maxPoolSize || 1);
   this.connectionOptions.connectionTimeout = (settings.connectionTimeout || 60);
 
   // Create the Connection Pool object.  It will be initialized once we
@@ -185,6 +185,7 @@ IBMDB.prototype.connect = function(cb) {
       self.dataSource.connected = false;
       self.dataSource.connecting = false;
     } else {
+      self.dataSource.connection = con;
       self.dataSource.connected = true;
       self.dataSource.connecting = false;
       self.dataSource.emit('connected');


### PR DESCRIPTION
Two changes were made to `lib/ibmdb.js`

- The min/max pool size would default to 0 not allowing any connections to be be created if you didn't set a min/max pool size.
- `this.dataSource.connection` is never set so when you test the ping function the if around `self.dataSource.conection` will never be triggered so I set `self.dataSource.conection` in the `connect` function.

Not sure if this is the best way to fix this issue but it does seem to fix the errors when running `npm test`.