### PR TITLE
Update ibm_db minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "debug": "^2.2.0",
-    "ibm_db": "^1.0.0",
+    "ibm_db": "^2.0.0",
     "loopback-connector": "^2.3.0",
     "strong-globalize": "^2.8.0"
   },


### PR DESCRIPTION
node-ibmdb has released a new version which contains many updates that customers are already relying on and are required for updates to the informix connector.  This PR just increases to the 2.0.0 stream.