### PR TITLE
Upgrade to loopback-connector@3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "async": "^1.5.0",
     "debug": "^2.2.0",
     "ibm_db": "^2.0.0",
-    "loopback-connector": "^2.3.0",
+    "loopback-connector": "^3.0.0",
     "strong-globalize": "^2.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "loopback-ibmdb",
   "version": "1.0.12",
   "description": "LoopBack Connector common code for IBM databases",
+  "engines": {
+    "node": ">=4"
+  },
   "keywords": [
     "IBM",
     "StrongLoop",


### PR DESCRIPTION
Update dependency version of loopback-connector to 3.x

Now CI test of db2 connectors cannot pick the latest code in loopback-connector@master, because `loopback-ibmdb` is still using `loopback-connector@2.x`
And dropping node@0.10, 0.12 support as well.