### PR TITLE
Add getTableStatus to ibmdb/mig

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -47,6 +47,40 @@ module.exports = function(IBMDB) {
     });
   };
 
+  IBMDB.prototype.getTableStatus = function(model, cb) {
+    var self = this;
+    var columnSQL;
+    var indexSQL;
+
+    columnSQL = 'SELECT COLNAME AS NAME, TYPENAME AS DATATYPE, ' +
+      'COLNO, LENGTH AS DATALENGTH, NULLS FROM SYSCAT.COLUMNS ' +
+      'WHERE TRIM(TABNAME) LIKE \'' +
+      self.table(model) + '\' ' +
+      'AND TRIM(TABSCHEMA) LIKE \'' +
+      self.schema + '\'' +
+      ' ORDER BY COLNO';
+
+    self.execute(columnSQL, function(err, tableInfo) {
+      if (err) {
+        cb(err);
+      } else {
+        indexSQL = 'SELECT TABNAME, TABSCHEMA, INDNAME, ' +
+          'COLNAMES, UNIQUERULE FROM SYSCAT.INDEXES ' +
+          'WHERE TRIM(TABNAME) LIKE \'' +
+          self.table(model) + '\' ' +
+          'AND TRIM(TABSCHEMA) LIKE \'' +
+          self.schema + '\'';
+
+        self.execute(indexSQL, function(err, indexInfo) {
+          if (err) {
+            console.log(err);
+          }
+          cb(err, tableInfo, indexInfo);
+        });
+      }
+    });
+  };
+
   IBMDB.prototype.alterTable = function(model, actualFields, actualIndexes,
     callback, checkOnly) {
     var self = this;


### PR DESCRIPTION
@jannyHou PTAL

In `loopback-connector`, `getTableStatus` only callback result when `fields` and `indexes` both exist, https://github.com/strongloop/loopback-connector/blob/master/lib/sql.js#L236 

While db2 connectors allow empty value of them.