### PR TITLE
Fix replaceById bug when id not found

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -644,9 +644,27 @@ IBMDB.prototype.buildIndexes = function(model) {
   debug('IBMDB.prototype.buildIndexes %j', model);
 };
 
+IBMDB.prototype.buildReplace = function(model, where, data, options) {
+  debug('IBMDB.prototype.buildReplace: model=$s, where=%j, options=%j',
+        model, where, options);
+  var self = this;
+  var idName = self.idName(model);
+  var fields = self.buildFieldsForReplace(model, data);
+  var updateClause = new ParameterizedSQL('UPDATE ' + self.tableEscaped(model));
+  var whereClause = self.buildWhere(model, where);
+  var selectClause = new ParameterizedSQL('SELECT COUNT(\"' + idName + '\") ' +
+                                      'AS \"affectedRows\" FROM FINAL TABLE(');
+
+  updateClause.merge([fields, whereClause]);
+  selectClause.merge([updateClause, ')']);
+
+  return (selectClause);
+};
+
 IBMDB.prototype.getCountForAffectedRows = function(model, info) {
-  var affectedRows = info && typeof info.affectedRows === 'number' ?
-      info.affectedRows : undefined;
+  var affectedRows = info && info[0] &&
+      typeof info[0].affectedRows === 'number' ?
+      info[0].affectedRows : undefined;
   return affectedRows;
 };
 


### PR DESCRIPTION
### Description:

connect to https://github.com/strongloop-internal/scrum-apex/issues/110
Fix replaceById bug when id does not exist in db. 

Test cases are in juggler. 