### PR TITLE
Set connection properties

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -85,8 +85,7 @@ IBMDB.prototype.setConnectionProperties = function(name, settings) {
       ';UID=' + this.username +
       ';PWD=' + this.password +
       ';PORT=' + this.portnumber +
-      ';PROTOCOL=' + this.protocol +
-      ';AUTHENTICATION=SERVER';
+      ';PROTOCOL=' + this.protocol;
     self.connStr = connStrGenerate;
 
     self.schema = this.username;

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -42,34 +42,41 @@ function IBMDB(name, settings) {
   debug('IBMDB constructor settings: %j', settings);
   SQLConnector.call(this, name, settings);
 
-  this.dbname = (settings.database || settings.db || 'testdb');
-  this.dsn = settings.dsn;
-  this.hostname = (settings.hostname || settings.host);
-  this.username = (settings.username || settings.user);
-  this.password = settings.password;
-  this.portnumber = settings.port;
-  this.protocol = (settings.protocol || 'TCPIP');
-
-  // Save off the connectionOptions passed in for connection pooling
-  this.connectionOptions = {};
-  this.connectionOptions.minPoolSize = parseInt(settings.minPoolSize, 10) || 0;
-  this.connectionOptions.maxPoolSize = parseInt(settings.maxPoolSize, 10) || 0;
-  this.connectionOptions.connectionTimeout =
-    parseInt(settings.connectionTimeout, 10) || 60;
-
   // Create the Connection Pool object.  It will be initialized once we
   // have the connection string prepped below.
+  this.setConnectionProperties(name, settings);
   this.client = new Driver.Pool(this.connectionOptions);
+  this.client.init(this.connectionOptions.minPoolSize, this.connStr);
+};
+
+util.inherits(IBMDB, SQLConnector);
+
+IBMDB.prototype.setConnectionProperties = function(name, settings) {
+  var self = this;
+  self.dbname = (settings.database || settings.db || 'testdb');
+  self.dsn = settings.dsn;
+  self.hostname = (settings.hostname || settings.host);
+  self.username = (settings.username || settings.user);
+  self.password = settings.password;
+  self.portnumber = settings.port;
+  self.protocol = (settings.protocol || 'TCPIP');
+
+  // Save off the connectionOptions passed in for connection pooling
+  self.connectionOptions = {};
+  self.connectionOptions.minPoolSize = parseInt(settings.minPoolSize, 10) || 0;
+  self.connectionOptions.maxPoolSize = parseInt(settings.maxPoolSize, 10) || 0;
+  self.connectionOptions.connectionTimeout =
+    parseInt(settings.connectionTimeout, 10) || 60;
 
   var dsn = settings.dsn;
   if (dsn) {
-    this.connStr = dsn;
+    self.connStr = dsn;
 
-    var DSNObject = parseDSN(dsn);
+    var DSNObject = self.parseDSN(dsn);
     if (!('CurrentSchema' in DSNObject)) {
-      this.connStr += ';CurrentSchema=' + DSNObject.UID;
+      self.connStr += ';CurrentSchema=' + DSNObject.UID;
     }
-    this.schema = DSNObject.CurrentSchema || DSNObject.UID;
+    self.schema = DSNObject.CurrentSchema || DSNObject.UID;
   } else {
     var connStrGenerate =
       'DRIVER={' + name + '}' +
@@ -78,23 +85,21 @@ function IBMDB(name, settings) {
       ';UID=' + this.username +
       ';PWD=' + this.password +
       ';PORT=' + this.portnumber +
-      ';PROTOCOL=' + this.protocol;
-    this.connStr = connStrGenerate;
+      ';PROTOCOL=' + this.protocol +
+      ';AUTHENTICATION=SERVER';
+    self.connStr = connStrGenerate;
 
-    this.schema = this.username;
+    self.schema = this.username;
     if (settings.schema) {
-      this.schema = settings.schema.toUpperCase();
+      self.schema = settings.schema.toUpperCase();
     }
 
-    this.connStr += ';CurrentSchema=' + this.schema;
+    self.connStr += ';CurrentSchema=' + self.schema;
   }
-
-  this.client.init(this.connectionOptions.minPoolSize, this.connStr);
 };
 
-util.inherits(IBMDB, SQLConnector);
 
-function parseDSN(dsn) {
+IBMDB.prototype.parseDSN = function(dsn) {
   // Split dsn into an array of optionStr
   var dsnOption = dsn.split(';');
   // Handle dsn string ended with ';'
@@ -110,7 +115,7 @@ function parseDSN(dsn) {
   });
 
   return result;
-}
+};
 
 IBMDB.prototype.tableEscaped = function(model) {
   var escapedName = this.escapeName(this.table(model));


### PR DESCRIPTION
Adding the setConnectionProperties prototype to allow the connection settings to differ for each IBM connector.  For example, DB2 allows the use of "CurrentSchema" in the DSN but doesn't allow for "AUTHENTICATION=SERVER" while Informix does not allow "CurrentSchema" but requires "AUTHENTICATION=SERVER"