### PR TITLE
Replace discovery migration

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -755,49 +755,49 @@ IBMDB.prototype.buildIndex = function(model, property) {
     return '';
   }
 
-  var stmt = 'CREATE ';
-  var kind = '';
+  var statement = new ParameterizedSQL('CREATE');
   if (i.kind) {
-    kind = i.kind;
+    statement.merge(i.kind);
+  } else if (i.unique && i.unique === true) {
+    statement.merge('UNIQUE');
   }
+
   var columnName = self.columnEscaped(model, property);
-  if (typeof i === 'object' && i.unique && i.unique === true) {
-    kind = 'UNIQUE';
-  }
-  return (stmt + kind + ' INDEX ' + columnName +
-          ' ON ' + self.schema + '.' + self.tableEscaped(model) +
-          ' (' + columnName + ');\n');
+
+  statement.merge('INDEX ' + columnName + ' ON ' + self.schema + '.');
+  statement.merge(self.tableEscaped(model) + '(' + columnName + ')');
+
+  return(statement.sql);
 };
 
 IBMDB.prototype.buildIndexes = function(model) {
   debug('IBMDB.prototype.buildIndexes');
+  var self = this;
   var indexClauses = [];
   var definition = this.getModelDefinition(model);
   var indexes = definition.settings.indexes || {};
   // Build model level indexes
   for (var index in indexes) {
     var i = indexes[index];
-    var stmt = 'CREATE ';
-    var kind = '';
+    var statement = new ParameterizedSQL('CREATE');
     if (i.kind) {
-      kind = i.kind;
-    }
-    var indexedColumns = [];
-    var indexName = this.escapeName(index);
-    if (Array.isArray(i.keys)) {
-      indexedColumns = i.keys.map(function(key) {
-        return this.columnEscaped(model, key);
-      });
+      statement.merge(i.kind);
+    } else if (i.unique && i.unique === true) {
+      statement.merge('UNIQUE');
     }
 
-    var columns = (i.columns.split(/,\s*/)).join('\",\"');
-    if (indexedColumns.length > 0) {
-      columns = indexedColumns.join('\",\"');
-    }
+    var columns = i.columns.split(/,\s*/);
+    columns.forEach(function(column) {
+      column = self.escapeName(column);
+    });
 
-    indexClauses.push(stmt + kind + ' INDEX ' + indexName +
-                      ' ON ' + this.schema + '.' + this.tableEscaped(model) +
-                      ' (\"' + columns + '\");\n');
+    console.log('INDEX: ', i);
+
+    statement.merge('INDEX ' + self.escapeName(index) + ' ON ');
+    statement.merge(self.schema + '.' + self.tableEscaped(model));
+    statement.merge('(' + columns + ')');
+
+    indexClauses.push(statement.sql);
   }
 
   return indexClauses;

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -881,8 +881,6 @@ IBMDB.prototype.buildIndexes = function(model) {
       column = self.escapeName(column);
     });
 
-    console.log('INDEX: ', i);
-
     statement.merge('INDEX ' + self.escapeName(index) + ' ON ');
     statement.merge(self.schema + '.' + self.tableEscaped(model));
     statement.merge('(' + columns + ')');

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -589,7 +589,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
           });
         });
       } else {
-        return cb(errorIdNotFoundForReplace(where.id));
+        return cb(self.errorIdNotFoundForReplace(where.id));
       }
     });
   };

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -217,7 +217,7 @@ IBMDB.prototype.escapeName = function(name) {
  *
  */
 IBMDB.prototype.executeSQL = function(sql, params, options, callback) {
-  debug('DB2.prototype.executeSQL (enter)',
+  debug('IBMDB.prototype.executeSQL (enter)',
         sql, params, options);
 
   var self = this;
@@ -254,7 +254,7 @@ IBMDB.prototype.executeSQL = function(sql, params, options, callback) {
     stmt.params = params;
 
     conn.query(stmt, function(err, data, more) {
-      debug('DB2.prototype.executeSQL (exit)' +
+      debug('IBMDB.prototype.executeSQL (exit)' +
             ' stmt=%j params=%j err=%j data=%j more=%j',
             stmt, params, err, data, more);
       // schedule callback as there is more code to
@@ -532,23 +532,210 @@ IBMDB.prototype.updateOrCreate = IBMDB.prototype.save =
   };
 
 /**
- * Create the table for the given model
+ * Replace if the model instance exists with the same id
+ * or create a new instance
  *
  * @param {string} model The model name
- * @param {Object} [options] options
- * @param {Function} [cb] The callback function
+ * @param {Object} data The model instance data
+ * @param {Function} [callback] The callback function
  */
-IBMDB.prototype.createTable = function(model, options, cb) {
-  debug('IBMDB.prototype.createTable ', model, options);
-  cb();
+IBMDB.prototype._replace = function(model, where, data, options, callback) {
+  debug('IBMDB.prototype._replace (enter): model=%j, data=%j, ' +
+        'options=%j\n', model, data, options);
+  var self = this;
+  var idName = self.idName(model);
+  var stmt;
+  var tableName = self.tableEscaped(model);
+  var meta = {};
+
+  function executeWithConnection(connection, cb) {
+    // Execution for _replace requires running 3
+    // separate SQL statements. The last depends on the
+    // result of the first couple.
+    // var where = {};
+    // where[idName] = data[idName];
+
+    var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
+    countStmt.merge(tableName);
+    countStmt.merge(self.buildWhere(model, where));
+    countStmt.noResults = false;
+
+    connection.query(countStmt, function(err, countData) {
+      debug('IBMDB.prototype._replace stmt: %j data: %j err: %j\n',
+            countStmt, countData, err);
+      if (err) return cb(err);
+
+      if (countData[0]['CNT'] > 0) { 
+        // remove existing to replace with a new insert
+        stmt = self.buildUpdate(model, where, data);
+        stmt.noResults = true;
+        connection.query(stmt, function(err, res) {
+          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
+                stmt, res, err);
+
+          if (err) return cb(err);
+
+          meta.isNewInstance = countData[0]['CNT'] === 0;
+          cb(null, data, meta);
+        });  
+      } else {
+        stmt = self.buildInsert(model, data);
+        stmt.noResults = true;
+
+        connection.query(stmt, function(err, sData) {
+          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
+                stmt, sData, err);
+
+          if (err) return cb(err);
+
+          meta.isNewInstance = countData[0]['CNT'] === 0;
+          cb(null, data, meta);
+        });
+      }
+    });
+  };
+
+  if (options.transaction) {
+    executeWithConnection(options.transaction.connection,
+      function(err, data, meta) {
+        if (err) {
+          return callback && callback(err);
+        } else {
+          return callback && callback(null, data, meta);
+        }
+      });
+  } else {
+    self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
+      if (err) {
+        return callback && callback(err);
+      }
+      executeWithConnection(conn, function(err, data, meta) {
+        if (err) {
+          conn.rollbackTransaction(function(err) {
+            conn.close(function() {});
+            return callback && callback(err);
+          });
+        } else {
+          options.transaction = undefined;
+          conn.commitTransaction(function(err) {
+            if (err) {
+              return callback && callback(err);
+            }
+
+            conn.close(function() {});
+            return callback && callback(null, data, meta);
+          });
+        }
+      });
+    });
+  }
 };
 
-IBMDB.prototype.buildIndex = function(model, property) {
-  debug('IBMDB.prototype.buildIndex %j %j', model, property);
-};
+/**
+ * Replace if the model instance exists with the same id
+ * or create a new instance
+ *
+ * @param {string} model The model name
+ * @param {Object} data The model instance data
+ * @param {Function} [callback] The callback function
+ */
+IBMDB.prototype.replaceOrCreate = function(model, data, options, callback) {
+  debug('IBMDB.prototype.replaceOrCreate (enter): model=%j, data=%j, ' +
+        'options=%j\n', model, data, options);
+  var self = this;
+  var idName = self.idName(model);
+  var stmt;
+  var tableName = self.tableEscaped(model);
+  var meta = {};
 
-IBMDB.prototype.buildIndexes = function(model) {
-  debug('IBMDB.prototype.buildIndexes %j', model);
+  function executeWithConnection(connection, cb) {
+    // Execution for replaceOrCreate requires running 3
+    // separate SQL statements. The last depends on the
+    // result of the first couple.
+    var where = {};
+    where[idName] = data[idName];
+
+    var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
+    countStmt.merge(tableName);
+    countStmt.merge(self.buildWhere(model, where));
+    countStmt.noResults = false;
+
+    connection.query(countStmt, function(err, countData) {
+      debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err: %j\n',
+            countStmt, countData, err);
+      if (err) return cb(err);
+
+      if (countData[0]['CNT'] > 0) {
+        // remove existing to replace with a new insert
+        stmt = self.buildDelete(model, where);
+        stmt.noResults = true;
+        connection.query(stmt, function(err, res) {
+          debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                stmt, res, err);
+
+          if (err) return cb(err);
+
+          stmt = self.buildInsert(model, data);
+
+          connection.query(stmt, function(err, sData) {
+            debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                  stmt, sData, err);
+            if (err) return cb(err);
+
+            meta.isNewInstance = countData[0]['CNT'] === 0;
+            cb(null, data, meta);
+          });
+        });
+      } else {
+        stmt = self.buildInsert(model, data);
+        stmt.noResults = true;
+
+        connection.query(stmt, function(err, sData) {
+          debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                stmt, sData, err);
+          if (err) return cb(err);
+
+          meta.isNewInstance = countData[0]['CNT'] === 0;
+          cb(null, data, meta);
+        });
+      }
+    });
+  };
+
+  if (options.transaction) {
+    executeWithConnection(options.transaction.connection,
+      function(err, data, meta) {
+        if (err) {
+          return callback && callback(err);
+        } else {
+          return callback && callback(null, data, meta);
+        }
+      });
+  } else {
+    self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
+      if (err) {
+        return callback && callback(err);
+      }
+      executeWithConnection(conn, function(err, data, meta) {
+        if (err) {
+          conn.rollbackTransaction(function(err) {
+            conn.close(function() {});
+            return callback && callback(err);
+          });
+        } else {
+          options.transaction = undefined;
+          conn.commitTransaction(function(err) {
+            if (err) {
+              return callback && callback(err);
+            }
+
+            conn.close(function() {});
+            return callback && callback(null, data, meta);
+          });
+        }
+      });
+    });
+  }
 };
 
 IBMDB.prototype.buildReplace = function(model, where, data, options) {
@@ -823,213 +1010,6 @@ IBMDB.prototype.convertNumberType = function convertNumberType(p, defaultType) {
   }
 
   return dt;
-};
-
-/**
- * Replace if the model instance exists with the same id
- * or create a new instance
- *
- * @param {string} model The model name
- * @param {Object} data The model instance data
- * @param {Function} [callback] The callback function
- */
-IBMDB.prototype._replace = function(model, where, data, options, callback) {
-  debug('IBMDB.prototype._replace (enter): model=%j, data=%j, ' +
-        'options=%j\n', model, data, options);
-  var self = this;
-  var idName = self.idName(model);
-  var stmt;
-  var tableName = self.tableEscaped(model);
-  var meta = {};
-
-  function executeWithConnection(connection, cb) {
-    // Execution for _replace requires running 3
-    // separate SQL statements. The last depends on the
-    // result of the first couple.
-    // var where = {};
-    // where[idName] = data[idName];
-
-    var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
-    countStmt.merge(tableName);
-    countStmt.merge(self.buildWhere(model, where));
-    countStmt.noResults = false;
-
-    connection.query(countStmt, function(err, countData) {
-      debug('IBMDB.prototype._replace stmt: %j data: %j err: %j\n',
-            countStmt, countData, err);
-      if (err) return cb(err);
-
-      if (countData[0]['CNT'] > 0) {
-        // remove existing to replace with a new insert
-        stmt = self.buildUpdate(model, where, data);
-        stmt.noResults = true;
-        connection.query(stmt, function(err, res) {
-          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
-                stmt, res, err);
-
-          if (err) return cb(err);
-
-          meta.isNewInstance = countData[0]['CNT'] === 0;
-          cb(null, data, meta);
-        });
-      } else {
-        stmt = self.buildInsert(model, data);
-        stmt.noResults = true;
-
-        connection.query(stmt, function(err, sData) {
-          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
-                stmt, sData, err);
-
-          if (err) return cb(err);
-
-          meta.isNewInstance = countData[0]['CNT'] === 0;
-          cb(null, data, meta);
-        });
-      }
-    });
-  };
-
-  if (options.transaction) {
-    executeWithConnection(options.transaction.connection,
-      function(err, data, meta) {
-        if (err) {
-          return callback && callback(err);
-        } else {
-          return callback && callback(null, data, meta);
-        }
-      });
-  } else {
-    self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
-      if (err) {
-        return callback && callback(err);
-      }
-      executeWithConnection(conn, function(err, data, meta) {
-        if (err) {
-          conn.rollbackTransaction(function(err) {
-            conn.close(function() {});
-            return callback && callback(err);
-          });
-        } else {
-          options.transaction = undefined;
-          conn.commitTransaction(function(err) {
-            if (err) {
-              return callback && callback(err);
-            }
-
-            conn.close(function() {});
-            return callback && callback(null, data, meta);
-          });
-        }
-      });
-    });
-  }
-};
-
-/**
- * Replace if the model instance exists with the same id
- * or create a new instance
- *
- * @param {string} model The model name
- * @param {Object} data The model instance data
- * @param {Function} [callback] The callback function
- */
-IBMDB.prototype.replaceOrCreate = function(model, data, options, callback) {
-  debug('IBMDB.prototype.replaceOrCreate (enter): model=%j, data=%j, ' +
-        'options=%j\n', model, data, options);
-  var self = this;
-  var idName = self.idName(model);
-  var stmt;
-  var tableName = self.tableEscaped(model);
-  var meta = {};
-
-  function executeWithConnection(connection, cb) {
-    // Execution for replaceOrCreate requires running 3
-    // separate SQL statements. The last depends on the
-    // result of the first couple.
-    var where = {};
-    where[idName] = data[idName];
-
-    var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
-    countStmt.merge(tableName);
-    countStmt.merge(self.buildWhere(model, where));
-    countStmt.noResults = false;
-
-    connection.query(countStmt, function(err, countData) {
-      debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err: %j\n',
-            countStmt, countData, err);
-      if (err) return cb(err);
-
-      if (countData[0]['CNT'] > 0) {
-        // remove existing to replace with a new insert
-        stmt = self.buildDelete(model, where);
-        stmt.noResults = true;
-        connection.query(stmt, function(err, res) {
-          debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
-                stmt, res, err);
-
-          if (err) return cb(err);
-
-          stmt = self.buildInsert(model, data);
-
-          connection.query(stmt, function(err, sData) {
-            debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
-                  stmt, sData, err);
-            if (err) return cb(err);
-
-            meta.isNewInstance = countData[0]['CNT'] === 0;
-            cb(null, data, meta);
-          });
-        });
-      } else {
-        stmt = self.buildInsert(model, data);
-        stmt.noResults = true;
-
-        connection.query(stmt, function(err, sData) {
-          debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
-                stmt, sData, err);
-          if (err) return cb(err);
-
-          meta.isNewInstance = countData[0]['CNT'] === 0;
-          cb(null, data, meta);
-        });
-      }
-    });
-  };
-
-  if (options.transaction) {
-    executeWithConnection(options.transaction.connection,
-      function(err, data, meta) {
-        if (err) {
-          return callback && callback(err);
-        } else {
-          return callback && callback(null, data, meta);
-        }
-      });
-  } else {
-    self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
-      if (err) {
-        return callback && callback(err);
-      }
-      executeWithConnection(conn, function(err, data, meta) {
-        if (err) {
-          conn.rollbackTransaction(function(err) {
-            conn.close(function() {});
-            return callback && callback(err);
-          });
-        } else {
-          options.transaction = undefined;
-          conn.commitTransaction(function(err) {
-            if (err) {
-              return callback && callback(err);
-            }
-
-            conn.close(function() {});
-            return callback && callback(null, data, meta);
-          });
-        }
-      });
-    });
-  }
 };
 
 function stringOptions(p, columnType) {

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -536,14 +536,15 @@ IBMDB.prototype.updateOrCreate = IBMDB.prototype.save =
  * or create a new instance
  *
  * @param {string} model The model name
+ * @param {Object} where clause
  * @param {Object} data The model instance data
+ * @param {Object} options for this call
  * @param {Function} [callback] The callback function
  */
 IBMDB.prototype._replace = function(model, where, data, options, callback) {
   debug('IBMDB.prototype._replace (enter): model=%j, data=%j, ' +
         'options=%j\n', model, data, options);
   var self = this;
-  var idName = self.idName(model);
   var stmt;
   var tableName = self.tableEscaped(model);
   var meta = {};
@@ -552,8 +553,6 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
     // Execution for _replace requires running 3
     // separate SQL statements. The last depends on the
     // result of the first couple.
-    // var where = {};
-    // where[idName] = data[idName];
 
     var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
     countStmt.merge(tableName);
@@ -565,7 +564,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
             countStmt, countData, err);
       if (err) return cb(err);
 
-      if (countData[0]['CNT'] > 0) { 
+      if (countData[0]['CNT'] > 0) {
         // remove existing to replace with a new insert
         stmt = self.buildUpdate(model, where, data);
         stmt.noResults = true;
@@ -577,7 +576,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
 
           meta.isNewInstance = countData[0]['CNT'] === 0;
           cb(null, data, meta);
-        });  
+        });
       } else {
         stmt = self.buildInsert(model, data);
         stmt.noResults = true;
@@ -637,6 +636,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
  *
  * @param {string} model The model name
  * @param {Object} data The model instance data
+ * @param {Object} options for this function call
  * @param {Function} [callback] The callback function
  */
 IBMDB.prototype.replaceOrCreate = function(model, data, options, callback) {
@@ -857,7 +857,7 @@ IBMDB.prototype.buildIndex = function(model, property) {
   statement.merge('INDEX ' + columnName + ' ON ' + self.schema + '.');
   statement.merge(self.tableEscaped(model) + '(' + columnName + ')');
 
-  return(statement.sql);
+  return (statement.sql);
 };
 
 IBMDB.prototype.buildIndexes = function(model) {

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -510,7 +510,7 @@ IBMDB.prototype.updateOrCreate = IBMDB.prototype.save =
         }
         executeWithConnection(conn, function(err, data, meta) {
           if (err) {
-            conn.rollbackTransaction(function(err) {
+            conn.rollbackTransaction(function() {
               conn.close(function() {});
               return callback && callback(err);
             });
@@ -571,7 +571,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
         stmt = self.buildDelete(model, where);
         stmt.noResults = true;
         connection.query(stmt, function(err, res) {
-          debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
                 stmt, res, err);
 
           if (err) return cb(err);
@@ -580,7 +580,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
           stmt = self.buildInsert(model, data);
 
           connection.query(stmt, function(err, sData) {
-            debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+            debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
                   stmt, sData, err);
             if (err) return cb(err);
 
@@ -610,7 +610,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
       }
       executeWithConnection(conn, function(err, data, meta) {
         if (err) {
-          conn.rollbackTransaction(function(err) {
+          conn.rollbackTransaction(function() {
             conn.close(function() {});
             return callback && callback(err);
           });
@@ -655,17 +655,18 @@ IBMDB.prototype.replaceOrCreate = function(model, data, options, callback) {
     var where = {};
     where[idName] = data[idName];
 
-    var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
-    countStmt.merge(tableName);
-    countStmt.merge(self.buildWhere(model, where));
-    countStmt.noResults = false;
+    var selectStmt = new ParameterizedSQL('SELECT ' + self.escapeName(idName) +
+                                          ' FROM ');
+    selectStmt.merge(tableName);
+    selectStmt.merge(self.buildWhere(model, where));
+    selectStmt.noResults = false;
 
-    connection.query(countStmt, function(err, countData) {
+    connection.query(selectStmt, function(err, selectData) {
       debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err: %j\n',
-            countStmt, countData, err);
+            selectStmt, selectData, err);
       if (err) return cb(err);
 
-      if (countData[0]['CNT'] > 0) {
+      if (selectData.length > 0) {
         // remove existing to replace with a new insert
         stmt = self.buildDelete(model, where);
         stmt.noResults = true;
@@ -682,7 +683,7 @@ IBMDB.prototype.replaceOrCreate = function(model, data, options, callback) {
                   stmt, sData, err);
             if (err) return cb(err);
 
-            meta.isNewInstance = countData[0]['CNT'] === 0;
+            meta.isNewInstance = (selectData.length === 0);
             cb(null, data, meta);
           });
         });
@@ -695,7 +696,7 @@ IBMDB.prototype.replaceOrCreate = function(model, data, options, callback) {
                 stmt, sData, err);
           if (err) return cb(err);
 
-          meta.isNewInstance = countData[0]['CNT'] === 0;
+          meta.isNewInstance = (selectData.length === 0);
           cb(null, data, meta);
         });
       }
@@ -718,7 +719,7 @@ IBMDB.prototype.replaceOrCreate = function(model, data, options, callback) {
       }
       executeWithConnection(conn, function(err, data, meta) {
         if (err) {
-          conn.rollbackTransaction(function(err) {
+          conn.rollbackTransaction(function() {
             conn.close(function() {});
             return callback && callback(err);
           });

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -532,103 +532,6 @@ IBMDB.prototype.updateOrCreate = IBMDB.prototype.save =
   };
 
 /**
- * Replace if the model instance exists with the same id
- * or create a new instance
- *
- * @param {string} model The model name
- * @param {Object} data The model instance data
- * @param {Function} [callback] The callback function
- */
-IBMDB.prototype.replaceOrCreate = IBMDB.prototype.replace =
-  function(model, data, options, callback) {
-    debug('IBMDB.prototype.replaceOrCreate (enter): model=%j, data=%j, ' +
-          'options=%j\n', model, data, options);
-    var self = this;
-    var idName = self.idName(model);
-    var stmt;
-    var tableName = self.tableEscaped(model);
-    var meta = {};
-
-    function executeWithConnection(connection, cb) {
-      // Execution for replaceOrCreate requires running 3
-      // separate SQL statements. The last depends on the
-      // result of the first couple.
-      var where = {};
-      where[idName] = data[idName];
-
-      var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
-      countStmt.merge(tableName);
-      countStmt.merge(self.buildWhere(model, where));
-      countStmt.noResults = false;
-
-      connection.query(countStmt, function(err, countData) {
-        debug('IBMDB.prototype.replaceOrCreate (data): err=%j, countData=%j\n',
-              err, countData);
-        if (err) return cb(err);
-
-        if (countData[0]['CNT'] > 0) {
-          // remove existing to replace with a new insert
-          stmt = self.buildDelete(model, where);
-          stmt.noResults = true;
-          connection.query(stmt, function(err, res) {
-            debug('IBMDB.prototype.replaceOrCreate (data): err=%j, res=%j\n',
-                  err, res);
-
-            if (err) return cb(err);
-          });
-        }
-        stmt = self.buildInsert(model, data);
-        stmt.noResults = true;
-
-        connection.query(stmt, function(err, sData) {
-          debug('IBMDB.prototype.replaceOrCreate (data): err=%j, sData=%j\n',
-                err, sData);
-
-          if (err) return cb(err);
-
-          meta.isNewInstance = countData[0]['CNT'] === 0;
-          cb(null, data, meta);
-        });
-      });
-    };
-
-    if (options.transaction) {
-      executeWithConnection(options.transaction.connection,
-        function(err, data, meta) {
-          if (err) {
-            return callback && callback(err);
-          } else {
-            return callback && callback(null, data, meta);
-          }
-        });
-    } else {
-      self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
-        if (err) {
-          return callback && callback(err);
-        }
-        executeWithConnection(conn, function(err, data, meta) {
-          if (err) {
-            conn.rollbackTransaction(function(err) {
-              conn.close(function() {});
-              return callback && callback(err);
-            });
-          } else {
-            options.transaction = undefined;
-            conn.commitTransaction(function(err) {
-              if (err) {
-                return callback && callback(err);
-              }
-
-              conn.close(function() {});
-              return callback && callback(null, data, meta);
-            });
-          }
-        });
-      });
-    }
-  };
-
-/**
  * Create the table for the given model
  *
  * @param {string} model The model name
@@ -920,6 +823,213 @@ IBMDB.prototype.convertNumberType = function convertNumberType(p, defaultType) {
   }
 
   return dt;
+};
+
+/**
+ * Replace if the model instance exists with the same id
+ * or create a new instance
+ *
+ * @param {string} model The model name
+ * @param {Object} data The model instance data
+ * @param {Function} [callback] The callback function
+ */
+IBMDB.prototype._replace = function(model, where, data, options, callback) {
+  debug('IBMDB.prototype._replace (enter): model=%j, data=%j, ' +
+        'options=%j\n', model, data, options);
+  var self = this;
+  var idName = self.idName(model);
+  var stmt;
+  var tableName = self.tableEscaped(model);
+  var meta = {};
+
+  function executeWithConnection(connection, cb) {
+    // Execution for _replace requires running 3
+    // separate SQL statements. The last depends on the
+    // result of the first couple.
+    // var where = {};
+    // where[idName] = data[idName];
+
+    var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
+    countStmt.merge(tableName);
+    countStmt.merge(self.buildWhere(model, where));
+    countStmt.noResults = false;
+
+    connection.query(countStmt, function(err, countData) {
+      debug('IBMDB.prototype._replace stmt: %j data: %j err: %j\n',
+            countStmt, countData, err);
+      if (err) return cb(err);
+
+      if (countData[0]['CNT'] > 0) {
+        // remove existing to replace with a new insert
+        stmt = self.buildUpdate(model, where, data);
+        stmt.noResults = true;
+        connection.query(stmt, function(err, res) {
+          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
+                stmt, res, err);
+
+          if (err) return cb(err);
+
+          meta.isNewInstance = countData[0]['CNT'] === 0;
+          cb(null, data, meta);
+        });
+      } else {
+        stmt = self.buildInsert(model, data);
+        stmt.noResults = true;
+
+        connection.query(stmt, function(err, sData) {
+          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
+                stmt, sData, err);
+
+          if (err) return cb(err);
+
+          meta.isNewInstance = countData[0]['CNT'] === 0;
+          cb(null, data, meta);
+        });
+      }
+    });
+  };
+
+  if (options.transaction) {
+    executeWithConnection(options.transaction.connection,
+      function(err, data, meta) {
+        if (err) {
+          return callback && callback(err);
+        } else {
+          return callback && callback(null, data, meta);
+        }
+      });
+  } else {
+    self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
+      if (err) {
+        return callback && callback(err);
+      }
+      executeWithConnection(conn, function(err, data, meta) {
+        if (err) {
+          conn.rollbackTransaction(function(err) {
+            conn.close(function() {});
+            return callback && callback(err);
+          });
+        } else {
+          options.transaction = undefined;
+          conn.commitTransaction(function(err) {
+            if (err) {
+              return callback && callback(err);
+            }
+
+            conn.close(function() {});
+            return callback && callback(null, data, meta);
+          });
+        }
+      });
+    });
+  }
+};
+
+/**
+ * Replace if the model instance exists with the same id
+ * or create a new instance
+ *
+ * @param {string} model The model name
+ * @param {Object} data The model instance data
+ * @param {Function} [callback] The callback function
+ */
+IBMDB.prototype.replaceOrCreate = function(model, data, options, callback) {
+  debug('IBMDB.prototype.replaceOrCreate (enter): model=%j, data=%j, ' +
+        'options=%j\n', model, data, options);
+  var self = this;
+  var idName = self.idName(model);
+  var stmt;
+  var tableName = self.tableEscaped(model);
+  var meta = {};
+
+  function executeWithConnection(connection, cb) {
+    // Execution for replaceOrCreate requires running 3
+    // separate SQL statements. The last depends on the
+    // result of the first couple.
+    var where = {};
+    where[idName] = data[idName];
+
+    var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
+    countStmt.merge(tableName);
+    countStmt.merge(self.buildWhere(model, where));
+    countStmt.noResults = false;
+
+    connection.query(countStmt, function(err, countData) {
+      debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err: %j\n',
+            countStmt, countData, err);
+      if (err) return cb(err);
+
+      if (countData[0]['CNT'] > 0) {
+        // remove existing to replace with a new insert
+        stmt = self.buildDelete(model, where);
+        stmt.noResults = true;
+        connection.query(stmt, function(err, res) {
+          debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                stmt, res, err);
+
+          if (err) return cb(err);
+
+          stmt = self.buildInsert(model, data);
+
+          connection.query(stmt, function(err, sData) {
+            debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                  stmt, sData, err);
+            if (err) return cb(err);
+
+            meta.isNewInstance = countData[0]['CNT'] === 0;
+            cb(null, data, meta);
+          });
+        });
+      } else {
+        stmt = self.buildInsert(model, data);
+        stmt.noResults = true;
+
+        connection.query(stmt, function(err, sData) {
+          debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                stmt, sData, err);
+          if (err) return cb(err);
+
+          meta.isNewInstance = countData[0]['CNT'] === 0;
+          cb(null, data, meta);
+        });
+      }
+    });
+  };
+
+  if (options.transaction) {
+    executeWithConnection(options.transaction.connection,
+      function(err, data, meta) {
+        if (err) {
+          return callback && callback(err);
+        } else {
+          return callback && callback(null, data, meta);
+        }
+      });
+  } else {
+    self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
+      if (err) {
+        return callback && callback(err);
+      }
+      executeWithConnection(conn, function(err, data, meta) {
+        if (err) {
+          conn.rollbackTransaction(function(err) {
+            conn.close(function() {});
+            return callback && callback(err);
+          });
+        } else {
+          options.transaction = undefined;
+          conn.commitTransaction(function(err) {
+            if (err) {
+              return callback && callback(err);
+            }
+
+            conn.close(function() {});
+            return callback && callback(null, data, meta);
+          });
+        }
+      });
+    });
+  }
 };
 
 function stringOptions(p, columnType) {

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -545,6 +545,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
   debug('IBMDB.prototype._replace (enter): model=%j, data=%j, ' +
         'options=%j\n', model, data, options);
   var self = this;
+  var idName = self.idName(model);
   var stmt;
   var tableName = self.tableEscaped(model);
   var meta = {};
@@ -554,42 +555,41 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
     // separate SQL statements. The last depends on the
     // result of the first couple.
 
-    var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
-    countStmt.merge(tableName);
-    countStmt.merge(self.buildWhere(model, where));
-    countStmt.noResults = false;
+    var selectStmt = new ParameterizedSQL('SELECT ' + self.escapeName(idName) +
+                                          ' FROM ');
+    selectStmt.merge(tableName);
+    selectStmt.merge(self.buildWhere(model, where));
+    selectStmt.noResults = false;
 
-    connection.query(countStmt, function(err, countData) {
+    connection.query(selectStmt, function(err, selectData) {
       debug('IBMDB.prototype._replace stmt: %j data: %j err: %j\n',
-            countStmt, countData, err);
+            selectStmt, selectData, err);
       if (err) return cb(err);
 
-      if (countData[0]['CNT'] > 0) {
+      if (selectData.length > 0) {
         // remove existing to replace with a new insert
-        stmt = self.buildUpdate(model, where, data);
+        stmt = self.buildDelete(model, where);
         stmt.noResults = true;
         connection.query(stmt, function(err, res) {
-          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
+          debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
                 stmt, res, err);
 
           if (err) return cb(err);
 
-          meta.isNewInstance = countData[0]['CNT'] === 0;
-          cb(null, data, meta);
+          data[idName] = selectData[0][idName];
+          stmt = self.buildInsert(model, data);
+
+          connection.query(stmt, function(err, sData) {
+            debug('IBMDB.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                  stmt, sData, err);
+            if (err) return cb(err);
+
+            meta.isNewInstance = (selectData.length > 0);
+            cb(null, data, meta);
+          });
         });
       } else {
-        stmt = self.buildInsert(model, data);
-        stmt.noResults = true;
-
-        connection.query(stmt, function(err, sData) {
-          debug('IBMDB.prototype._replace stmt: %j data: %j err=%j\n',
-                stmt, sData, err);
-
-          if (err) return cb(err);
-
-          meta.isNewInstance = countData[0]['CNT'] === 0;
-          cb(null, data, meta);
-        });
+        return cb(errorIdNotFoundForReplace(where.id));
       }
     });
   };
@@ -848,7 +848,7 @@ IBMDB.prototype.buildIndex = function(model, property) {
   var statement = new ParameterizedSQL('CREATE');
   if (i.kind) {
     statement.merge(i.kind);
-  } else if (i.unique && i.unique === true) {
+  } else if (i.unique) {
     statement.merge('UNIQUE');
   }
 
@@ -872,13 +872,12 @@ IBMDB.prototype.buildIndexes = function(model) {
     var statement = new ParameterizedSQL('CREATE');
     if (i.kind) {
       statement.merge(i.kind);
-    } else if (i.unique && i.unique === true) {
+    } else if (i.unique) {
       statement.merge('UNIQUE');
     }
 
-    var columns = i.columns.split(/,\s*/);
-    columns.forEach(function(column) {
-      column = self.escapeName(column);
+    var columns = i.columns.split(',').map(function(val) {
+      return self.escapeName(val);
     });
 
     statement.merge('INDEX ' + self.escapeName(index) + ' ON ');

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -589,7 +589,7 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
           });
         });
       } else {
-        return cb(self.errorIdNotFoundForReplace(where.id));
+        return cb(errorIdNotFoundForReplace(where.id));
       }
     });
   };
@@ -1039,5 +1039,13 @@ IBMDB.prototype.applyPagination = function(model, stmt, filter) {
   var limitClause = buildLimit(filter.limit, filter.offset || filter.skip);
   return stmt.merge(limitClause);
 };
+
+function errorIdNotFoundForReplace(idValue) {
+  var msg = g.f('Could not replace. Object with id %s does not exist!',
+                idValue);
+  var error = new Error(msg);
+  error.statusCode = error.status = 404;
+  return error;
+}
 
 require('./migration')(IBMDB);


### PR DESCRIPTION
This code adds the _replace function for the IBM connectors and fixes up some issues with the replaceOrCreate function.  It also contains a few minor typo's and removal of dead code.