### PR TITLE
Make the autoupdate logic much more generic

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -123,7 +123,7 @@ module.exports = function(IBMDB) {
     return operations;
   };
 
-  IBMDB.prototype.addIndexes = function(model, actualIndexes) {
+  IBMDB.prototype.dropIndexes = function(model, actualIndexes) {
     var ai = {};
     var self = this;
     var m = this.getModelDefinition(model);
@@ -138,114 +138,16 @@ module.exports = function(IBMDB) {
     var sql = [];
     var type = '';
 
+    // If there are indexes for this table then we need to drop them.
+    // Generate the statements here to drop all known indexes.
     if (actualIndexes) {
       actualIndexes.forEach(function(i) {
-        var name = i.INDNAME;
-        if (!ai[name]) {
-          ai[name] = {
-            info: i,
-            columns: [],
-          };
-        }
-
-        i.COLNAMES.split(/\+\s*/).forEach(function(columnName, j) {
-          // This is a bit of a dirty way to get around this but DB2 returns
-          // column names as a string started with and separated by a '+'.
-          // The code below will strip out the initial '+' then store the
-          // actual column names.
-          if (j > 0)
-            ai[name].columns[j - 1] = columnName;
-        });
+        var stmt = 'DROP INDEX ' + i.INDNAME;
+        operations.push(stmt);
       });
     }
-    var aiNames = Object.keys(ai);
-    // remove indexes
-    aiNames.forEach(function(indexName) {
-      if (ai[indexName].info.UNIQUERULE === 'P' || // indexName === 'PRIMARY' ||
-        (m.properties[indexName] && self.id(model, indexName))) return;
 
-      if (indexNames.indexOf(indexName) === -1 && !m.properties[indexName] ||
-      m.properties[indexName] && !m.properties[indexName].index) {
-        if (ai[indexName].info.UNIQUERULE === 'P') {
-          operations.push('DROP PRIMARY KEY');
-        } else if (ai[indexName].info.UNIQUERULE === 'U') {
-          operations.push('DROP UNIQUE ' + indexName);
-        }
-      } else {
-        // first: check single (only type and kind)
-        if (m.properties[indexName] && !m.properties[indexName].index) {
-          // TODO
-          return;
-        }
-        // second: check multiple indexes
-        var orderMatched = true;
-        if (indexNames.indexOf(indexName) !== -1) {
-          m.settings.indexes[indexName].columns.split(/,\s*/).forEach(
-          function(columnName, i) {
-            if (ai[indexName].columns[i] !== columnName)
-              orderMatched = false;
-          });
-        }
-
-        if (!orderMatched) {
-          if (ai[indexName].info.UNIQUERULE === 'P') {
-            operations.push('DROP PRIMARY KEY');
-          } else if (ai[indexName].info.UNIQUERULE === 'U') {
-            operations.push('DROP UNIQUE ' + indexName);
-          }
-
-          delete ai[indexName];
-        }
-      }
-    });
-
-    if (operations.length) {
-      // Add the ALTER TABLE statement to the list of tasks to perform later.
-      sql.push('ALTER TABLE ' + self.schema + '.' +
-              self.tableEscaped(model) + ' ' + operations.join(' ') + ';');
-    }
-
-    // add single-column indexes
-    propNames.forEach(function(propName) {
-      var i = m.properties[propName].index;
-      if (!i) {
-        return;
-      }
-      var found = ai[propName] && ai[propName].info;
-      if (!found) {
-        var pName = propName;
-        type = '';
-        if (i.type) {
-          type = i.type;
-        }
-        sql.push('CREATE ' + type + ' INDEX ' + pName + ' ON ' +
-        self.schema + '.' + self.tableEscaped(model) +
-        '(\"' + pName + '\") ');
-      }
-    });
-
-    // add multi-column indexes
-    indexNames.forEach(function(indexName) {
-      var i = m.settings.indexes[indexName];
-      var found = ai[indexName] && ai[indexName].info;
-      if (!found) {
-        var iName = indexName;
-        var type = '';
-        if (i.type) {
-          type = i.type;
-        }
-        var stmt = 'CREATE ' + type + 'INDEX ' + iName + ' ON ' +
-        self.schema + '.' + self.tableEscaped(model) + '(';
-
-        var splitNames = i.columns.split(/,\s*/);
-        var colNames = splitNames.join('\",\"');
-
-        stmt += '\"' + colNames + '\")';
-
-        sql.push(stmt);
-      }
-    });
-    return sql;
+    return operations;
   };
 
   IBMDB.prototype.alterTable = function(model, actualFields, actualIndexes,
@@ -256,6 +158,12 @@ module.exports = function(IBMDB) {
     var sql = [];
     var tasks = [];
 
+    // Create the statements to drop all existing indexes before we start
+    // altering the table.
+    sql = sql.concat(self.dropIndexes(model, actualIndexes));
+
+    // Add/Modify and drop column statements for ALTER TABLE are generated
+    // prior to re-building the indexes as defined in the model.
     var operations = self.getAddModifyColumns(model, actualFields);
     operations = operations.concat(self.getDropColumns(model, actualFields));
 
@@ -264,7 +172,11 @@ module.exports = function(IBMDB) {
       sql.push('ALTER TABLE ' + self.schema + '.' +
               self.tableEscaped(model) + ' ' + operations.join(' ') + ';');
     }
-    sql = sql.concat(self.addIndexes(model, actualIndexes));
+
+    // Now that the column altering statments have been added we can add in the
+    // indexes again.
+    // ------------------------------------------------------------------------
+    sql = sql.concat(self.buildIndexes(model));
 
     sql.forEach(function(i) {
       tasks.push(function(cb) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -124,19 +124,7 @@ module.exports = function(IBMDB) {
   };
 
   IBMDB.prototype.dropIndexes = function(model, actualIndexes) {
-    var ai = {};
-    var self = this;
-    var m = this.getModelDefinition(model);
-    var indexes = m.settings.indexes || {};
-    var indexNames = Object.keys(indexes).filter(function(name) {
-      return !!m.settings.indexes[name];
-    });
     var operations = [];
-    var propNames = Object.keys(m.properties).filter(function(name) {
-      return !!m.properties[name];
-    });
-    var sql = [];
-    var type = '';
 
     // If there are indexes for this table then we need to drop them.
     // Generate the statements here to drop all known indexes.


### PR DESCRIPTION
The autoupdate logic was initially built for DB2 only and relied on system catalogs that do not apply to all databases in the IBM set.  These changes will make the autoupdate function much more generic and possibly more functionally correct as it ensures the order of operations will not cause issues such as a column of a table being dropped while an index using that column still exists in the database.

While this may not be the most performant version of autoupdate, this is unlikely to be something users do frequently and the rebuilding of the indexes may improve database performance in some cases.