### PR TITLE
Remove connection string logging

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -39,7 +39,6 @@ module.exports = IBMDB;
  * @constructor
  */
 function IBMDB(name, settings) {
-  debug('IBMDB constructor settings: %j', settings);
   SQLConnector.call(this, name, settings);
 
   // Create the Connection Pool object.  It will be initialized once we
@@ -185,7 +184,6 @@ IBMDB.prototype.connect = function(cb) {
 
   self.dataSource.connecting = true;
   self.client.open(this.connStr, function(err, con) {
-    debug('IBMDB.prototype.connect (%s) err=%j con=%j', self.connStr, err, con);
     if (err) {
       self.dataSource.connected = false;
       self.dataSource.connecting = false;


### PR DESCRIPTION
Remove debug logging of connection string details.

When a user has debug set for the connector the full connection string would be printed in the debug output.  This runs the risk of exposing login details for the database server and should printed even in the event debugging is enabled.  Note that be default debug is not enabled and users have to explicitly enable it for this printing to occur.