### PR TITLE
fix fromColumnValue when val is undefined

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -372,7 +372,7 @@ IBMDB.prototype.toColumnValue = function(prop, val) {
  */
 IBMDB.prototype.fromColumnValue = function(prop, val) {
   debug('IBMDB.prototype.fromColumnValue %j %j', prop, val);
-  if (val === null || !prop) {
+  if (val === undefined || val === null || !prop) {
     return val;
   }
   switch (prop.type.name) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "pretest": "eslint ./ && jscs ./",
     "lint": "eslint ./ && jscs ./",
-    "test": "mocha --timeout 10000"
+    "test": "mocha --timeout 10000 --require test/init.js test/*.js"
   },
   "dependencies": {
     "async": "^1.5.0",

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -6,7 +6,6 @@
 /* eslint-env node, mocha */
 var EventEmitter = require('events').EventEmitter;
 var IBMDB = require('../').IBMDB;
-require('./init.js');
 
 describe('basic connector', function() {
   var ds = new EventEmitter;

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: loopback-connector-db2
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+/* eslint-env node, mocha */
+process.env.NODE_ENV = 'test';
+var assert = require('assert');
+var EventEmitter = require('events').EventEmitter;
+var IBMDB = require('../').IBMDB;
+
+var db = new EventEmitter;
+
+describe('functional test', function() {
+  before(function(done) {
+    db.connector = new IBMDB('db2', global.config);
+    db.connector.dataSource = db;
+    done();
+  });
+  it('`fromColumnValue` function', function(done) {
+    var result = db.connector.fromColumnValue({}, undefined);
+    assert.equal(result, undefined);
+    done();
+  });
+});

--- a/test/ibmdb.config.test.js
+++ b/test/ibmdb.config.test.js
@@ -5,7 +5,6 @@
 
 /* eslint-env node, mocha */
 process.env.NODE_ENV = 'test';
-require('./init.js');
 var assert = require('assert');
 
 var config;


### PR DESCRIPTION
connected to: https://github.com/strongloop/loopback-ibmdb/issues/51

It gives error when parsing `val` when it's undefined. 