### PR TITLE
Escape column names on add/change/drop

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -68,7 +68,7 @@ module.exports = function(IBMDB) {
       if (found) {
         actualize(propName, found);
       } else {
-        operations.push('ADD COLUMN ' + propName + ' ' +
+        operations.push('ADD COLUMN ' + self.columnEscaped(propName) + ' ' +
         self.buildColumnDefinition(model, propName));
       }
     });
@@ -77,8 +77,8 @@ module.exports = function(IBMDB) {
       var newSettings = m.properties[propName];
       if (newSettings && changed(newSettings, oldSettings)) {
         // TODO: NO TESTS EXECUTE THIS CODE PATH
-        var pName = '\'' + propName + '\'';
-        operations.push('CHANGE COLUMN ' + pName + ' ' + pName + ' ' +
+        operations.push('CHANGE COLUMN ' + self.columnEscaped(propName) + ' ' +
+        self.columnEscaped(propName) + ' ' +
         self.buildColumnDefinition(model, propName));
       }
     }
@@ -116,7 +116,7 @@ module.exports = function(IBMDB) {
         var notFound = !~propNames.indexOf(f.NAME);
         if (m.properties[f.NAME] && self.id(model, f.NAME)) return;
         if (notFound || !m.properties[f.NAME]) {
-          operations.push('DROP COLUMN ' + f.NAME);
+          operations.push('DROP COLUMN ' + self.columnEscaped(f.NAME));
         }
       });
     }


### PR DESCRIPTION
Add escape function on the column names in add, change and drop operations to allow the underlying database deal with the name escaping.

connect to https://github.com/strongloop/loopback-ibmdb/issues/53