### PR TITLE
Fix columnEscaped params

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -289,20 +289,6 @@ IBMDB.prototype.executeSQL = function(sql, params, options, callback) {
   }
 };
 
-/**
- * Escape an identifier such as the column name
- * IBMDB requires double quotes for case-sensitivity
- *
- * @param {string} name A database identifier
- * @returns {string} The escaped database identifier
- */
-IBMDB.prototype.escapeName = function(name) {
-  debug('IBMDB.prototype.escapeName name=%j', name);
-  if (!name) return name;
-  name.replace(/["]/g, '""');
-  return '"' + name + '"';
-};
-
 function dateToIBMDB(val) {
   var dateStr = val.getFullYear() + '-'
       + fillZeros(val.getMonth() + 1) + '-'

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -68,8 +68,8 @@ module.exports = function(IBMDB) {
       if (found) {
         actualize(propName, found);
       } else {
-        operations.push('ADD COLUMN ' + self.columnEscaped(propName) + ' ' +
-        self.buildColumnDefinition(model, propName));
+        operations.push('ADD COLUMN ' + self.columnEscaped(model, propName) +
+        ' ' + self.buildColumnDefinition(model, propName));
       }
     });
 
@@ -77,8 +77,8 @@ module.exports = function(IBMDB) {
       var newSettings = m.properties[propName];
       if (newSettings && changed(newSettings, oldSettings)) {
         // TODO: NO TESTS EXECUTE THIS CODE PATH
-        operations.push('CHANGE COLUMN ' + self.columnEscaped(propName) + ' ' +
-        self.columnEscaped(propName) + ' ' +
+        operations.push('CHANGE COLUMN ' + self.columnEscaped(model, propName) +
+        ' ' + self.columnEscaped(model, propName) + ' ' +
         self.buildColumnDefinition(model, propName));
       }
     }
@@ -116,7 +116,7 @@ module.exports = function(IBMDB) {
         var notFound = !~propNames.indexOf(f.NAME);
         if (m.properties[f.NAME] && self.id(model, f.NAME)) return;
         if (notFound || !m.properties[f.NAME]) {
-          operations.push('DROP COLUMN ' + self.columnEscaped(f.NAME));
+          operations.push('DROP COLUMN ' + self.columnEscaped(model, f.NAME));
         }
       });
     }


### PR DESCRIPTION
# Description
- Fix `self.columnEscaped()` function params
- Remove duplicate `IBMDB.prototype.escapeName` function

connect to https://github.com/strongloop/loopback-ibmdb/issues/53