### PR TITLE
Override buildExpression from base connector

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -19,6 +19,9 @@ var async = require('async');
 var ParameterizedSQL = IBMDB.ParameterizedSQL = SQLConnector.ParameterizedSQL;
 var Transaction = IBMDB.Transaction = SQLConnector.Transaction;
 
+// The generic placeholder
+var PLACEHOLDER = SQLConnector.PLACEHOLDER = ParameterizedSQL.PLACEHOLDER;
+
 /**
  * Initialize the IBMDB connector for the given data source
  *
@@ -818,6 +821,92 @@ IBMDB.prototype.buildColumnDefinitions = function(model) {
   }
 
   return sql.join(',\n');
+};
+
+/**
+ * Build SQL expression
+ * @param {String} columnName Escaped column name
+ * @param {String} operator SQL operator
+ * @param {*} columnValue Column value
+ * @param {*} propertyValue Property value
+ * @returns {ParameterizedSQL} The SQL expression
+ */
+IBMDB.prototype.buildExpression =
+function(columnName, operator, columnValue, propertyValue) {
+  function buildClause(columnValue, separator, grouping) {
+    var values = [];
+    for (var i = 0, n = columnValue.length; i < n; i++) {
+      if (columnValue[i] instanceof ParameterizedSQL) {
+        values.push(columnValue[i]);
+      } else {
+        values.push(new ParameterizedSQL(PLACEHOLDER, [columnValue[i]]));
+      }
+    }
+    separator = separator || ',';
+    var clause = ParameterizedSQL.join(values, separator);
+    if (grouping) {
+      clause.sql = '(' + clause.sql + ')';
+    }
+    return clause;
+  }
+
+  var self = this;
+  var sqlExp = columnName;
+  var clause, stmt;
+  if (columnValue instanceof ParameterizedSQL) {
+    clause = columnValue;
+  } else {
+    clause = new ParameterizedSQL(PLACEHOLDER, [columnValue]);
+  }
+  switch (operator) {
+    case 'gt':
+      sqlExp += '>';
+      break;
+    case 'gte':
+      sqlExp += '>=';
+      break;
+    case 'lt':
+      sqlExp += '<';
+      break;
+    case 'lte':
+      sqlExp += '<=';
+      break;
+    case 'between':
+      sqlExp += ' BETWEEN ';
+      clause = buildClause(columnValue, ' AND ', false);
+      break;
+    case 'inq':
+      sqlExp += ' IN ';
+      clause = buildClause(columnValue, ',', true);
+      break;
+    case 'nin':
+      sqlExp += ' NOT IN ';
+      clause = buildClause(columnValue, ',', true);
+      break;
+    case 'neq':
+      if (columnValue == null) {
+        return new ParameterizedSQL(sqlExp + ' IS NOT NULL');
+      }
+      sqlExp += '!=';
+      break;
+    case 'like':
+      sqlExp += ' LIKE ';
+      break;
+    case 'nlike':
+      sqlExp += ' NOT LIKE ';
+      break;
+    case 'regexp':
+      // doc on `regexp_like`: https://www.ibm.com/support/knowledgecenter/SSEPGG_11.1.0/com.ibm.db2.luw.sql.ref.doc/doc/r0061494.html
+      var ignCaseFlag = columnValue.ignoreCase ? 'i' : 'c';
+      var multiLineFlag = columnValue.multiline ? 'm' : '';
+      var flags = ignCaseFlag + multiLineFlag;
+
+      sqlExp = `REGEXP_LIKE(${columnName}, '${columnValue.source}', 
+      '${flags}')`;
+      return sqlExp;
+  }
+  stmt = ParameterizedSQL.join([sqlExp, clause], '');
+  return stmt;
 };
 
 IBMDB.prototype.buildIndex = function(model, property) {


### PR DESCRIPTION
# Description

Override `buildExpression` function from base sql connector to allow db2/dashdb based regexp syntax.

The function is exactly the same as the one in [base connector](https://github.com/strongloop/loopback-connector/blob/master/lib/sql.js#L978) except the case for regexp in this [line](https://github.com/strongloop/loopback-ibmdb/compare/fix/override-buildExpression?expand=1#diff-4264eb1de5b89690cd7cd0ff815b745bR900)

connect to https://github.com/strongloop/loopback-connector-dashdb/issues/51