### PR TITLE
Add support for BIGINT datatype

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+2018-08-17, Version 2.4.0
+=========================
+
+ * Update package versions (#70) (Quentin Presley)
+
+ * Revert change to strong-globalize version (#69) (Quentin Presley)
+
+ * Changing strong-globalize level to 4.1.0 (#68) (Quentin Presley)
+
+ * [WebFM] cs/pl/ru translation (candytangnb)
+
+ * chore: update license (Diana Lau)
+
+
 2017-10-18, Version 2.3.0
 =========================
 

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -1053,7 +1053,7 @@ IBMDB.prototype.buildColumnType = function buildColumnType(propertyDefinition) {
       dt = 'ENUM(' + p.type._string + ')';
       dt = stringOptions(p, dt);
       break;
-    case 'BigInt`:
+    case 'BigInt':
       dt = 'BIGINT';
       break;
   }

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -1053,6 +1053,9 @@ IBMDB.prototype.buildColumnType = function buildColumnType(propertyDefinition) {
       dt = 'ENUM(' + p.type._string + ')';
       dt = stringOptions(p, dt);
       break;
+    case 'BigInt`:
+      dt = 'BIGINT';
+      break;
   }
   debug('IBMDB.prototype.buildColumnType %j %j', p.type.name, dt);
   return dt;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-ibmdb",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "LoopBack Connector common code for IBM databases",
   "engines": {
     "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "^3.1.0",
     "ibm_db": "^2.0.0",
     "loopback-connector": "^4.0.0",
-    "strong-globalize": "^3.1.0"
+    "strong-globalize": "^4.1.0"
   },
   "devDependencies": {
     "eslint": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "^3.1.0",
     "ibm_db": "^2.0.0",
     "loopback-connector": "^4.0.0",
-    "strong-globalize": "^4.1.0"
+    "strong-globalize": "^3.1.0"
   },
   "devDependencies": {
     "eslint": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "description": "LoopBack Connector common code for IBM databases",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "keywords": [
     "IBM",
@@ -22,16 +22,16 @@
   "dependencies": {
     "async": "^1.5.0",
     "debug": "^3.1.0",
-    "ibm_db": "^2.0.0",
+    "ibm_db": "^2.3.0",
     "loopback-connector": "^4.0.0",
-    "strong-globalize": "^3.1.0"
+    "strong-globalize": "^4.0.0"
   },
   "devDependencies": {
-    "eslint": "^4.3.0",
-    "eslint-config-loopback": "^8.0.0",
+    "eslint": "^5.3.0",
+    "eslint-config-loopback": "^11.0.0",
     "jscs": "^3.0.7",
-    "loopback-datasource-juggler": "^3.0.0",
-    "mocha": "^3.0.0"
+    "loopback-datasource-juggler": "^3.23.0",
+    "mocha": "^5.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
This PR adds a simple line to allow the user to specify a type of `BigInt` when creating a model.  Doing so allows for support of the `BIGINT` type vs. the currently `INTEGER` type used when a JS type of `Number` is passed in.  This fix addresses https://github.com/strongloop/loopback-connector-dashdb/issues/70 more generally by allowing it to work for DB2, DB2z, DB2iSeries and DashDB.

#### Related issues
- connect to strongloop/loopback-connect-dashdb#70

### Checklist
Tests will need to be added to DB2/DB2z/DB2i/DashDB connectors in separate PRs.
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
