### PR TITLE
Changing strong-globalize level to 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "^3.1.0",
     "ibm_db": "^2.0.0",
     "loopback-connector": "^4.0.0",
-    "strong-globalize": "^3.1.0"
+    "strong-globalize": "^4.1.0"
   },
   "devDependencies": {
     "eslint": "^4.3.0",


### PR DESCRIPTION
### Description
The old strong-globalize level of 3.1.0 seems to pull in swagger-client which has a dependency on `kyles-hockey/js-yaml` which fails to install.

#### Related issues
Unable to install loopback-ibmdb and hence some connectors on some platforms due to failure to install dependent package

### Checklist
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
