### PR TITLE
Revert change to strong-globalize version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "debug": "^3.1.0",
     "ibm_db": "^2.0.0",
     "loopback-connector": "^4.0.0",
-    "strong-globalize": "^4.1.0"
+    "strong-globalize": "^3.1.0"
   },
   "devDependencies": {
     "eslint": "^4.3.0",


### PR DESCRIPTION
### Description
The install issue was not due to strong-globalize version it was due to kyleshockey/js-yaml required npmjs.org login in .npmrc.  If not logged in than this package will not install.  In the 3.1 version of strong-globalize this package is a required dependency, in 4.1 it is not.

#### Related issues
### Checklist
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
