### PR TITLE
Fix toColumnValue with proper default

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -332,6 +332,15 @@ IBMDB.prototype.toColumnValue = function(prop, val) {
   if (!prop) {
     return val;
   }
+
+  if (prop.type.name === undefined) {
+    // Some properties such as nested arrays end up with
+    // a type name of undefined.  Return these as stringified
+    // JSON for now until the upper layers can return consistent
+    // type definitions.
+    return JSON.stringify(val);
+  }
+
   switch (prop.type.name) {
     case 'Array':
     case 'Number':
@@ -350,7 +359,7 @@ IBMDB.prototype.toColumnValue = function(prop, val) {
     case 'Date':
       return dateToIBMDB(val);
     default:
-      JSON.stringify(val);
+      return JSON.stringify(val);
   }
 };
 
@@ -366,6 +375,7 @@ IBMDB.prototype.fromColumnValue = function(prop, val) {
   if (val === undefined || val === null || !prop) {
     return val;
   }
+
   switch (prop.type.name) {
     case 'Number':
       return Number(val);
@@ -381,9 +391,8 @@ IBMDB.prototype.fromColumnValue = function(prop, val) {
     case 'Array':
     case 'Object':
     case 'JSON':
-      return JSON.parse(val);
     default:
-      return val;
+      return JSON.parse(val);
   }
 };
 

--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -333,7 +333,6 @@ IBMDB.prototype.toColumnValue = function(prop, val) {
     return val;
   }
   switch (prop.type.name) {
-    default:
     case 'Array':
     case 'Number':
     case 'String':
@@ -350,6 +349,8 @@ IBMDB.prototype.toColumnValue = function(prop, val) {
       return String(val);
     case 'Date':
       return dateToIBMDB(val);
+    default:
+      JSON.stringify(val);
   }
 };
 


### PR DESCRIPTION
### Description
toColumnValue was only returning the val back to the user in the default type case.  This causes problems with embedded relations as they are defined as a JSON block with no proper type defined in the property.  The toColumnValue should either be able to distinguish the name of a type OR assume that type is a JSON object and return the stringified JSON text.

#### Related issues
### Checklist
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
