### PR TITLE
Handle ms part of timestamps correctly for DB2

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -294,11 +294,11 @@ function dateToIBMDB(val) {
       fillZeros(val.getSeconds()) + '.';
   var ms = val.getMilliseconds();
   if (ms < 10) {
-    ms = '00000' + ms;
+    ms = '00' + ms + '000';
   } else if (ms < 100) {
-    ms = '0000' + ms;
+    ms = '0' + ms + '000';
   } else {
-    ms = '000' + ms;
+    ms = ms + '000';
   }
   return dateStr + ms;
   function fillZeros(v) {

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -24,4 +24,21 @@ describe('functional test', function() {
     assert.equal(result, undefined);
     done();
   });
+  it('`toColumnValue` function returns ms in the first 3 digits of µs', function(done) {
+    var prop = {
+      type: {
+        name: 'Date'
+      }
+    }
+    var dateValue = new Date(1999, 0, 9, 10, 11, 12, 1)
+    var result = db.connector.toColumnValue(prop, dateValue);
+    assert.equal(result, '1999-01-09-10.11.12.001000');
+    dateValue.setMilliseconds(12);
+    result = db.connector.toColumnValue(prop, dateValue);
+    assert.equal(result, '1999-01-09-10.11.12.012000');
+    dateValue.setMilliseconds(123);
+    result = db.connector.toColumnValue(prop, dateValue);
+    assert.equal(result, '1999-01-09-10.11.12.123000');
+    done(); 
+  });
 });

--- a/test/functional.test.js
+++ b/test/functional.test.js
@@ -24,21 +24,22 @@ describe('functional test', function() {
     assert.equal(result, undefined);
     done();
   });
-  it('`toColumnValue` function returns ms in the first 3 digits of µs', function(done) {
-    var prop = {
-      type: {
-        name: 'Date'
-      }
-    }
-    var dateValue = new Date(1999, 0, 9, 10, 11, 12, 1)
-    var result = db.connector.toColumnValue(prop, dateValue);
-    assert.equal(result, '1999-01-09-10.11.12.001000');
-    dateValue.setMilliseconds(12);
-    result = db.connector.toColumnValue(prop, dateValue);
-    assert.equal(result, '1999-01-09-10.11.12.012000');
-    dateValue.setMilliseconds(123);
-    result = db.connector.toColumnValue(prop, dateValue);
-    assert.equal(result, '1999-01-09-10.11.12.123000');
-    done(); 
-  });
+  it('`toColumnValue` function returns ms in the first 3 digits of µs',
+    function(done) {
+      var prop = {
+        type: {
+          name: 'Date',
+        },
+      };
+      var dateValue = new Date(1999, 0, 9, 10, 11, 12, 1);
+      var result = db.connector.toColumnValue(prop, dateValue);
+      assert.equal(result, '1999-01-09-10.11.12.001000');
+      dateValue.setMilliseconds(12);
+      result = db.connector.toColumnValue(prop, dateValue);
+      assert.equal(result, '1999-01-09-10.11.12.012000');
+      dateValue.setMilliseconds(123);
+      result = db.connector.toColumnValue(prop, dateValue);
+      assert.equal(result, '1999-01-09-10.11.12.123000');
+      done();
+    });
 });


### PR DESCRIPTION
### Description

Today, when using the loopback-connector-db2, milliseconds are handled incorrectly: milliseconds of date objects are stored in timestamps as if they were microseconds (1 ms is stored in DB2 as 1 μs and are lost when you read them back from DB2). This PR contains a new test that will fail without the also included change of dateToIBMDB function in lib/ibmdb.js. The changed code puts milliseconds in the first three digits of the microsecond part of timestamps.

#### Related issues

No issue has been created.

### Checklist

- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
