### PR TITLE
feat: drop node 6.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.1",
   "description": "LoopBack Connector common code for IBM databases",
   "engines": {
-    "node": ">=6"
+    "node": ">=8.9"
   },
   "keywords": [
     "IBM",


### PR DESCRIPTION
### Description

Dropping support for node 6.x.

#### Related issues

connect to: https://github.com/strongloop/loopback-ibmdb/issues/79 

[PR #80](https://github.com/strongloop/loopback-ibmdb/pull/80) depends on this  PR.

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->


### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
