### PR TITLE
fix: during replace, use id column name if specified

### DIFF
--- a/lib/ibmdb.js
+++ b/lib/ibmdb.js
@@ -584,7 +584,9 @@ IBMDB.prototype._replace = function(model, where, data, options, callback) {
 
           if (err) return cb(err);
 
-          data[idName] = selectData[0][idName];
+          // need to use column name (if available)
+          // when obtaining value from 'selectData'
+          data[idName] = selectData[0][self.idColumn(model)];
           stmt = self.buildInsert(model, data);
 
           connection.query(stmt, function(err, sData) {


### PR DESCRIPTION
### Description

Relate to : https://github.com/strongloop/loopback-ibmdb/issues/84 


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
