### PR TITLE
chore: drop Node.js 20 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.9",
   "description": "LoopBack Connector common code for IBM databases",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "keywords": [
     "IBM",
@@ -45,5 +45,5 @@
     "url": "https://github.com/strongloop/loopback-ibmdb/issues"
   },
   "license": "Artistic-2.0",
-  "author": "IBM Corp."
+  "author": "IBM Corp. and LoopBack contributors"
 }


### PR DESCRIPTION
### Description
Node.js 20 has reached EOL (https://nodejs.org/en/about/previous-releases), so dropping Node.js 20 support in this module.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
